### PR TITLE
Remove old temperature sensor call

### DIFF
--- a/ats-mini/Utils.cpp
+++ b/ats-mini/Utils.cpp
@@ -19,11 +19,9 @@ static bool sleep_on = false;
 // Current SSB patch status
 static bool ssbLoaded = false;
 
-extern "C" uint8_t temprature_sens_read();
-
 float getInternalTemperature()
 {
-  return (temprature_sens_read() - 32) / 1.8;
+  return temperatureRead();
 }
 
 // Time


### PR DESCRIPTION
## Summary
- drop legacy `temprature_sens_read` declaration
- use `temperatureRead()` in `getInternalTemperature`

## Testing
- `make -C ats-mini build` *(fails: `arduino-cli` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a0ebddbc8322aced4ab986e37d35