### PR TITLE
Use built‑in 7‑segment font for standby clock

### DIFF
--- a/ats-mini/Draw.cpp
+++ b/ats-mini/Draw.cpp
@@ -222,10 +222,10 @@ void drawClockStandby()
     spr.fillSprite(TH.bg);
     spr.setTextDatum(MC_DATUM);
     spr.setTextColor(TH.freq_text, TH.bg);
-    spr.setFreeFont(&Orbitron_Light_24);
+    spr.setTextFont(8);
     const char *t = clockGet();
     if(!t) t = "--:--";
-    spr.drawString(t, 160, 85, 4);
+    spr.drawString(t, 160, 85, 8);
     spr.pushSprite(0, 0);
 
     uint32_t tm = millis();


### PR DESCRIPTION
## Summary
- switch standby clock to the 7‑segment built‑in font

## Testing
- `make -C ats-mini build` *(fails: `arduino-cli` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cf32cf4c8322984c20a1b3be27cf