### PR TITLE
Fix standby clock background

### DIFF
--- a/ats-mini/Draw.cpp
+++ b/ats-mini/Draw.cpp
@@ -219,9 +219,11 @@ void drawClockStandby()
 {
   while(true)
   {
-    spr.fillSprite(TH.bg);
+    // Draw clock with a fixed black background so it does not depend on theme
+    // colors. Use light grey digits on black to mimic a seven segment display.
+    spr.fillSprite(TFT_BLACK);
     spr.setTextDatum(MC_DATUM);
-    spr.setTextColor(TH.freq_text, TH.bg);
+    spr.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
     spr.setTextFont(8);
     const char *t = clockGet();
     if(!t) t = "--:--";


### PR DESCRIPTION
## Summary
- show clock on black background in `drawClockStandby`
- use grey digits with 7 segment font

## Testing
- `make build` *(fails: arduino-cli not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842beded4a883228e853ea776326cbe